### PR TITLE
0 and O haven been removed

### DIFF
--- a/src/main/java/se2/server/hanabi/HanabiApplication.java
+++ b/src/main/java/se2/server/hanabi/HanabiApplication.java
@@ -19,27 +19,10 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 )
 public class HanabiApplication {
 
-	/*
-	@Autowired
-	private SSHConnector sshConnector;
 
-
-	 */
 	public static void main(String[] args) {
 		SpringApplication.run(HanabiApplication.class, args);
 	}
 
-	/*
-	@PostConstruct
-	public void init() {
-		try {
-			Session session =sshConnector.connect();
-			System.out.println("SSH-Verbindung erfolgreich!");
-			session.disconnect();
-		} catch (Exception e) {
-			System.out.println("Verbindung zum SSH-Server fehlgeschlagen");
-		}
-	}
 
-	 */
 }

--- a/src/main/java/se2/server/hanabi/services/LobbyCodeGenerator.java
+++ b/src/main/java/se2/server/hanabi/services/LobbyCodeGenerator.java
@@ -3,7 +3,7 @@ package se2.server.hanabi.services;
 import java.security.SecureRandom;
 
 public class LobbyCodeGenerator {
-    private static final String Characters = "ABCDEFGHIJKLMNPQRSTUVWXYZ123456789";
+    private static final String Characters = "^[A-NP-Z1-9]+$";
     private static final int length = 6;
 
     private static final SecureRandom random = new SecureRandom();

--- a/src/main/java/se2/server/hanabi/services/LobbyCodeGenerator.java
+++ b/src/main/java/se2/server/hanabi/services/LobbyCodeGenerator.java
@@ -3,7 +3,7 @@ package se2.server.hanabi.services;
 import java.security.SecureRandom;
 
 public class LobbyCodeGenerator {
-    private static final String REGEX = "^[A-NP-Z1-9]+$";
+    private static final String REGEX = "ABCDEFGHJKLMNPQRSTUVWXYZ123456789";
     private static final int length = 6;
 
     private static final SecureRandom random = new SecureRandom();

--- a/src/main/java/se2/server/hanabi/services/LobbyCodeGenerator.java
+++ b/src/main/java/se2/server/hanabi/services/LobbyCodeGenerator.java
@@ -3,7 +3,7 @@ package se2.server.hanabi.services;
 import java.security.SecureRandom;
 
 public class LobbyCodeGenerator {
-    private static final String Characters = "^[A-NP-Z1-9]+$";
+    private static final String REGEX = "^[A-NP-Z1-9]+$";
     private static final int length = 6;
 
     private static final SecureRandom random = new SecureRandom();
@@ -11,8 +11,8 @@ public class LobbyCodeGenerator {
     public static String generateLobbyCode() {
         StringBuilder lobbyCode = new StringBuilder();
         for (int i = 0; i < length; i++) {
-            int index = random.nextInt(Characters.length());
-            lobbyCode.append(Characters.charAt(index));
+            int index = random.nextInt(REGEX.length());
+            lobbyCode.append(REGEX.charAt(index));
         }
         return lobbyCode.toString();
     }

--- a/src/main/java/se2/server/hanabi/services/LobbyCodeGenerator.java
+++ b/src/main/java/se2/server/hanabi/services/LobbyCodeGenerator.java
@@ -3,7 +3,7 @@ package se2.server.hanabi.services;
 import java.security.SecureRandom;
 
 public class LobbyCodeGenerator {
-    private static final String Characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    private static final String Characters = "ABCDEFGHIJKLMNPQRSTUVWXYZ123456789";
     private static final int length = 6;
 
     private static final SecureRandom random = new SecureRandom();


### PR DESCRIPTION
I have implemented a user-friendly lobby ID generator that creates unique, easy-to-remember lobby codes. I deliberately excluded the characters 0 and O to avoid confusion and improve readability.