### PR TITLE
Add backend start game endpoint

### DIFF
--- a/src/main/java/se2/server/hanabi/controllers/LobbyController.java
+++ b/src/main/java/se2/server/hanabi/controllers/LobbyController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 import se2.server.hanabi.model.Lobby;
 import se2.server.hanabi.model.Player;
 import se2.server.hanabi.services.LobbyManager;
+import se2.server.hanabi.util.GameRules;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -151,7 +152,7 @@ public class LobbyController {
                     .body("Game already started");
         }
         
-        if (lobby.getPlayers().size() <= 1) {
+        if (lobby.getPlayers().size() < GameRules.MIN_PLAYERS) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body("Not enough players to start game (minimum 2)");
         }

--- a/src/main/java/se2/server/hanabi/controllers/LobbyController.java
+++ b/src/main/java/se2/server/hanabi/controllers/LobbyController.java
@@ -151,7 +151,7 @@ public class LobbyController {
                     .body("Game already started");
         }
         
-        if (lobby.getPlayers().size() < 2) {
+        if (lobby.getPlayers().size() <= 1) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body("Not enough players to start game (minimum 2)");
         }
@@ -198,4 +198,24 @@ public class LobbyController {
         return ResponseEntity.ok(lobbyManager.getAllLobbies());
     }
 
+    @GetMapping("/start-game/{id}/status")
+    @Operation(
+            summary = "Check if the game has started in a lobby",
+            description = "Returns true if the game in the specified lobby has started, false otherwise.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "Game status retrieved",
+                            content = @io.swagger.v3.oas.annotations.media.Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(type = "boolean", example = "true")
+                            )),
+                    @ApiResponse(responseCode = "404", description = "Lobby not found")
+            }
+    )
+    public ResponseEntity<Boolean> isGameStarted(@PathVariable String id) {
+        Lobby lobby = lobbyManager.getLobby(id);
+        if (lobby == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        return ResponseEntity.ok(lobby.isGameStarted());
+    }
 }

--- a/src/test/java/se2/server/hanabi/controllers/LobbyControllerTest.java
+++ b/src/test/java/se2/server/hanabi/controllers/LobbyControllerTest.java
@@ -1,6 +1,7 @@
 package se2.server.hanabi.controllers;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -196,5 +197,37 @@ public class LobbyControllerTest {
         public LobbyManager lobbyManager() {
             return mock(LobbyManager.class);
         }
+    }
+
+    @Test
+    void isGameStarted_shouldReturnTrueIfStarted() throws Exception {
+        String lobbyId = "test123";
+        Lobby mockLobby = Mockito.mock(Lobby.class);
+        when(lobbyManager.getLobby(lobbyId)).thenReturn(mockLobby);
+        when(mockLobby.isGameStarted()).thenReturn(true);
+
+        mockMvc.perform(get("/start-game/{id}/status", lobbyId))
+                .andExpect(status().isOk())
+                .andExpect(content().string("true"));
+    }
+
+    @Test
+    void isGameStarted_shouldReturnFalseIfNotStarted() throws Exception {
+        String lobbyId = "test123";
+        Lobby mockLobby = Mockito.mock(Lobby.class);
+        when(lobbyManager.getLobby(lobbyId)).thenReturn(mockLobby);
+        when(mockLobby.isGameStarted()).thenReturn(false);
+
+        mockMvc.perform(get("/start-game/{id}/status", lobbyId))
+                .andExpect(status().isOk())
+                .andExpect(content().string("false"));
+    }
+
+    @Test
+    void isGameStarted_shouldReturnNotFoundIfLobbyMissing() throws Exception {
+        when(lobbyManager.getLobby("invalid")).thenReturn(null);
+
+        mockMvc.perform(get("/start-game/{id}/status", "invalid"))
+                .andExpect(status().isNotFound());
     }
 }


### PR DESCRIPTION
Added /start-game/{id} endpoint to LobbyController.
Allows host to start the game if at least 2 players are in the lobby.
Handles edge cases (lobby not found, already started, too few players).