### PR TITLE
Add CHEAT Action Type, Centralize Strike Logic, and Prevent Duplicate Strikes per Round

### DIFF
--- a/src/main/java/se2/server/hanabi/SimpleWebSocketHandler.java
+++ b/src/main/java/se2/server/hanabi/SimpleWebSocketHandler.java
@@ -138,6 +138,9 @@ public class SimpleWebSocketHandler extends TextWebSocketHandler {
                     value
                 );
                 break;
+            case CHEAT:
+                result = gameManager.incrementStrikes();
+                break;
             default:
                 session.sendMessage(new TextMessage("{\"error\": \"Unknown action type\"}"));
                 return;

--- a/src/main/java/se2/server/hanabi/api/GameStatus.java
+++ b/src/main/java/se2/server/hanabi/api/GameStatus.java
@@ -23,6 +23,7 @@ public class GameStatus {
     private final boolean gameLost;
     private final int currentScore;
     private final int currentPlayerId;
+    private final List<Card> ownHand;
 
     public GameStatus(
         List<Player> players, 
@@ -38,7 +39,8 @@ public class GameStatus {
         boolean gameOver, 
         boolean gameLost,
         int currentScore,
-        int currentPlayerId
+        int currentPlayerId,
+        List<Card> ownHand
         ) {
         this.players = players;
         this.playerCardIds = playerCardIds;
@@ -54,6 +56,7 @@ public class GameStatus {
         this.gameLost = gameLost;
         this.currentScore = currentScore;
         this.currentPlayerId = currentPlayerId;
+        this.ownHand = ownHand;
     }
 
     public List<Player> getPlayers() {
@@ -115,5 +118,9 @@ public class GameStatus {
 
     public int getCurrentPlayerId() {
         return currentPlayerId;
+    }
+
+    public List<Card> getOwnHand() {
+        return ownHand;
     }
 }

--- a/src/main/java/se2/server/hanabi/game/GameManager.java
+++ b/src/main/java/se2/server/hanabi/game/GameManager.java
@@ -184,10 +184,11 @@ public class GameManager {
         return drawService.drawCardToPlayerHand(this, playerId);
     }
 
-    public void incrementStrikes() {
+    public ActionResult incrementStrikes() {
         logger.info("Before increment: Strikes = " + gameState.getStrikes());
         gameState.incrementStrikes();
         logger.info("After increment: Strikes = " + gameState.getStrikes());
+        return ActionResult.success("Strike added.");
     }
 
     /**

--- a/src/main/java/se2/server/hanabi/game/GameManager.java
+++ b/src/main/java/se2/server/hanabi/game/GameManager.java
@@ -188,6 +188,7 @@ public class GameManager {
         logger.info("Before increment: Strikes = " + gameState.getStrikes());
         gameState.incrementStrikes();
         logger.info("After increment: Strikes = " + gameState.getStrikes());
+        gameState.checkEndCondition(); // Ensure game over is set if max strikes reached
         return ActionResult.success("Strike added.");
     }
 

--- a/src/main/java/se2/server/hanabi/game/GameManager.java
+++ b/src/main/java/se2/server/hanabi/game/GameManager.java
@@ -184,9 +184,15 @@ public class GameManager {
         return drawService.drawCardToPlayerHand(this, playerId);
     }
 
-    public ActionResult incrementStrikes() {
+    public synchronized ActionResult incrementStrikes() {
+        int currentTurn = gameState.getTurnCounter();
+        if (gameState.getLastStrikeTurn() == currentTurn) {
+            logger.info("Strike already given for this turn (" + currentTurn + "). Ignoring duplicate CHEAT action.");
+            return ActionResult.failure("Strike already given for this round.");
+        }
         logger.info("Before increment: Strikes = " + gameState.getStrikes());
         gameState.incrementStrikes();
+        gameState.setLastStrikeTurn(currentTurn);
         logger.info("After increment: Strikes = " + gameState.getStrikes());
         gameState.checkEndCondition(); // Ensure game over is set if max strikes reached
         return ActionResult.success("Strike added.");

--- a/src/main/java/se2/server/hanabi/game/GameManager.java
+++ b/src/main/java/se2/server/hanabi/game/GameManager.java
@@ -187,8 +187,7 @@ public class GameManager {
     public synchronized ActionResult incrementStrikes() {
         int currentTurn = gameState.getTurnCounter();
         if (gameState.getLastStrikeTurn() == currentTurn) {
-            logger.info("Strike already given for this turn (" + currentTurn + "). Ignoring duplicate CHEAT action.");
-            return ActionResult.failure("Strike already given for this round.");
+            return ActionResult.success("Strike already given for this round.");
         }
         logger.info("Before increment: Strikes = " + gameState.getStrikes());
         gameState.incrementStrikes();

--- a/src/main/java/se2/server/hanabi/game/GameManager.java
+++ b/src/main/java/se2/server/hanabi/game/GameManager.java
@@ -135,7 +135,8 @@ public class GameManager {
             gameState.isGameOver(),
             gameState.isGameLost(),
             gameState.getCurrentScore(),
-            gameState.getCurrentPlayerId()
+            gameState.getCurrentPlayerId(),
+            gameState.getHands().get(playerId) // send real hand for this player
         );
     }
     

--- a/src/main/java/se2/server/hanabi/game/GameState.java
+++ b/src/main/java/se2/server/hanabi/game/GameState.java
@@ -29,6 +29,8 @@ public class GameState {
     private boolean gameLost = false;
     private int finalTurnsRemaining = -1;
     private final GameLogger logger;
+    private int lastStrikeTurn = -1;
+    private int turnCounter = 0;
 
     /**
      * Constructor for the game state
@@ -179,9 +181,9 @@ public class GameState {
         if (gameOver) {
             return false;
         }
-
         currentPlayerIndex = (currentPlayerIndex + 1) % players.size();
-        logger.info("Turn advances to " + getCurrentPlayerId());
+        turnCounter++;
+        logger.info("Turn advances to " + getCurrentPlayerId() + ", turnCounter=" + turnCounter);
 
         removeExpiredShownHints();
         decrementHintsRemainingTurns();
@@ -380,5 +382,19 @@ public class GameState {
 
         int numHintsShown = cardsShowingColorHintsAndRemainingTurns.size() + cardsShowingValueHintsAndRemainingTurns.size();
         logger.info("Remaining turns for shown hints decremented. "+numHintsShown+" hints are shown");
+    }
+
+    public int getCurrentTurnNumber() {
+        return currentPlayerIndex;
+    }
+    public int getLastStrikeTurn() {
+        return lastStrikeTurn;
+    }
+    public void setLastStrikeTurn(int turn) {
+        lastStrikeTurn = turn;
+    }
+
+    public int getTurnCounter() {
+        return turnCounter;
     }
 }

--- a/src/main/java/se2/server/hanabi/model/GameActionMessage.java
+++ b/src/main/java/se2/server/hanabi/model/GameActionMessage.java
@@ -11,7 +11,8 @@ public class GameActionMessage {
     public enum ActionType {
         PLAY,
         DISCARD,
-        HINT
+        HINT,
+        CHEAT // Added CHEAT action type
     }
     
     @JsonProperty("type")

--- a/src/test/java/se2/server/hanabi/api/GameStatusTest.java
+++ b/src/test/java/se2/server/hanabi/api/GameStatusTest.java
@@ -69,7 +69,8 @@ class GameStatusTest {
         currentScore = 17;
         currentPlayerId = 1; // Using playerId
 
-        gameStatus = new GameStatus(players, playerCardIds, visibleHands, playedCards, discardPile, numRemaningCards, cardsShowingColorHints, cardsShowingValueHints, numRemainingHintTokens, strikes, gameOver, gameLost, currentScore, currentPlayerId);
+        List<Card> ownHand = new ArrayList<>(); // Add this for the new constructor
+        gameStatus = new GameStatus(players, playerCardIds, visibleHands, playedCards, discardPile, numRemaningCards, cardsShowingColorHints, cardsShowingValueHints, numRemainingHintTokens, strikes, gameOver, gameLost, currentScore, currentPlayerId, ownHand);
     }
 
     @Test
@@ -144,7 +145,8 @@ class GameStatusTest {
 
     @Test
     void testGameStatusWithGameOverTrue() {
-        GameStatus status = new GameStatus(players, playerCardIds, visibleHands, playedCards, discardPile, numRemaningCards, cardsShowingColorHints, cardsShowingValueHints, numRemainingHintTokens, strikes, true, gameLost, currentScore, currentPlayerId);
+        List<Card> ownHand = new ArrayList<>(); // Add this for the new constructor
+        GameStatus status = new GameStatus(players, playerCardIds, visibleHands, playedCards, discardPile, numRemaningCards, cardsShowingColorHints, cardsShowingValueHints, numRemainingHintTokens, strikes, true, gameLost, currentScore, currentPlayerId, ownHand);
         assertTrue(status.isGameOver());
     }
 }


### PR DESCRIPTION
This PR introduces robust support for cheat detection and strike handling in the Hanabi backend, centralizing and synchronizing strike logic to ensure consistent game state updates and prevent duplicate strikes within a single round.

Cheat/Own Hand Support:

The server always includes the player's own hand (ownHand) in the game state response.
The client updates and uses cheatHand from ownHand to support cheat mode and display the player's own cards when needed.
This ensures the cheat function works correctly after any play, discard, or hint action.

CHEAT Action Type:

Added a new CHEAT action type to `GameActionMessage` to support cheat detection and handling via the WebSocket API.

Centralized Strike Logic:

Refactored `incrementStrikes()` in `GameManager` to return an `ActionResult` object, standardizing responses for both normal and cheat-triggered strike increments.
The WebSocket handler (`SimpleWebSocketHandler`) now uses the unified `incrementStrikes()` method for both card play errors and CHEAT actions, reducing code duplication and improving maintainability.

Duplicate Strike Prevention:

Introduced a `turnCounter` in `GameState` that increments with each turn.
`incrementStrikes()` is now synchronized and uses the `turnCounter` to ensure only one strike can be given per round, even if multiple CHEAT actions are received.
If a strike has already been given for the current round, the backend returns a success message: `"Strike already given for this round."`


